### PR TITLE
feat(api): add a route to get user info

### DIFF
--- a/api/server.js
+++ b/api/server.js
@@ -4,6 +4,7 @@ import express from "express";
 
 import { logger } from "./logger.js";
 import authenticationRoutes from "./src/identities-access-management/routes/authentication-routes.js";
+import userRoutes from "./src/identities-access-management/routes/user-routes.js";
 import usersManagementRoutes from "./src/identities-access-management/routes/users-management-routes.js";
 import moodRoutes from "./src/moods/routes.js";
 import { AVAILABLE_SOURCES } from "./src/shared/constants.js";
@@ -40,6 +41,7 @@ server.use((req, res, next) => {
 server.use(authenticationRoutes);
 server.use(usersManagementRoutes);
 server.use(moodRoutes);
+server.use(userRoutes);
 // Catch error here
 server.use(errors);
 

--- a/api/src/identities-access-management/controllers/get-user-info-controller.js
+++ b/api/src/identities-access-management/controllers/get-user-info-controller.js
@@ -1,0 +1,24 @@
+import { logger } from "../../../logger.js";
+import { findUserByUserId } from "../repositories/users-repository.js";
+
+async function getUserInfoController(req, res, next) {
+  try {
+    const foundUser = await findUserByUserId(req.auth.userId);
+    if (foundUser) {
+      return res.status(200).json({
+        data: {
+          firstname: foundUser.firstname,
+          lastname: foundUser.lastname,
+          email: foundUser.email,
+          userType: foundUser.userType,
+        },
+      });
+    }
+    return res.status(404).send();
+  } catch (error) {
+    logger.error(`Error fetching user info: ${error}`);
+    next(error);
+  }
+}
+
+export { getUserInfoController };

--- a/api/src/identities-access-management/routes/user-routes.js
+++ b/api/src/identities-access-management/routes/user-routes.js
@@ -1,0 +1,9 @@
+import express from "express";
+
+import { getUserInfoController } from "../controllers/get-user-info-controller.js";
+import { checkUserAccess } from "../middlewares/check-user-access.js";
+
+const userRoutes = express.Router();
+userRoutes.get("/api/user", checkUserAccess, getUserInfoController);
+
+export default userRoutes;

--- a/api/tests/identities-access-management/acceptance/user-routes.test.js
+++ b/api/tests/identities-access-management/acceptance/user-routes.test.js
@@ -1,0 +1,46 @@
+import request from "supertest";
+import { describe, expect, it } from "vitest";
+
+import databaseBuilder from "../../../db/database-builder/index.js";
+import server from "../../../server.js";
+import { encodedToken } from "../../../src/identities-access-management/services/token-service.js";
+import { AVAILABLE_SOURCES } from "../../../src/shared/constants.js";
+
+describe("Acceptance | Identities Access Management | Routes | User routes", () => {
+  describe("GET /api/user", () => {
+    it("should return 200 status code and user info", async () => {
+      // given
+      const user = await databaseBuilder.factory.buildUser();
+      const token = encodedToken({ userId: user.id });
+      const headers = { from: AVAILABLE_SOURCES.MYMOOD, Authorization: `Bearer ${token}` };
+
+      // when
+      const response = await request(server)
+        .get("/api/user")
+        .set(headers);
+
+      // then
+      expect(response.status).toBe(200);
+      expect(response.body.data).toEqual({
+        firstname: user.firstname,
+        lastname: user.lastname,
+        email: user.email,
+        userType: user.userType,
+      });
+    });
+
+    it("should return 404 if user does not exist", async () => {
+      // given
+      const token = encodedToken({ userId: 123456789 });
+      const headers = { from: AVAILABLE_SOURCES.MYMOOD, Authorization: `Bearer ${token}` };
+
+      // when
+      const response = await request(server)
+        .get("/api/user")
+        .set(headers);
+
+      // then
+      expect(response.status).toBe(404);
+    });
+  });
+});


### PR DESCRIPTION
This pull request introduces a new `GET /api/user` endpoint to retrieve authenticated user information, integrates it into the Express server, and adds comprehensive acceptance tests to ensure correct behavior. The changes are organized into new route/controller implementation, server integration, and testing.

**New User Info Endpoint Implementation:**

* Added `getUserInfoController` in `get-user-info-controller.js` to fetch and return user details for the authenticated user, responding with 200 and user info or 404 if not found.
* Created `user-routes.js` to define the `/api/user` route, applying `checkUserAccess` middleware and the new controller.

**Server Integration:**

* Imported and registered `userRoutes` in `server.js` so the new endpoint is available in the API. [[1]](diffhunk://#diff-9a833c35e47340f0693af8115da337dff6f2a7576b805dc884d3437b8fec1228R7) [[2]](diffhunk://#diff-9a833c35e47340f0693af8115da337dff6f2a7576b805dc884d3437b8fec1228R44)

**Testing:**

* Added acceptance tests in `user-routes.test.js` to verify successful retrieval of user info and correct handling of non-existent users.