### PR TITLE
fix: fix the release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Release
+name: release
 
 on:
   workflow_dispatch:
@@ -29,11 +29,14 @@ jobs:
         with:
           node-version-file: .nvmrc
 
-      - name: Release (via official GitHub Action)
-        # Using the semantic-release GitHub Action so semantic-release doesn't have to be a repo dependency.
-        # This action runs semantic-release server-side and accepts the GITHUB_TOKEN. It also supports a dry-run input.
-        uses: semantic-release/[email protected]
-        with:
-          dry-run: ${{ inputs.dry-run }}
+      - name: Release with semantic-release
+        uses: cycjimmy/semantic-release-action@v4
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          dry_run: ${{ github.event.inputs['dry-run'] }}
+          extra_plugins: |
+            @semantic-release/exec
+            @semantic-release/changelog
+            @semantic-release/git
+            conventional-changelog-conventionalcommits


### PR DESCRIPTION
This pull request updates the release workflow configuration to use a different GitHub Action for semantic-release and improves plugin management. The main changes are a switch to the `cycjimmy/semantic-release-action`, updated input handling, and explicit plugin specification.

**Release workflow updates:**

* Changed the workflow name from `Release` to `release` for consistency.
* Replaced the official `semantic-release` GitHub Action with `cycjimmy/semantic-release-action@v4` in `.github/workflows/release.yml`, allowing for more flexible configuration.
* Updated input handling for dry-run to use `github.event.inputs['dry-run']` instead of the previous syntax.
* Added explicit specification of extra semantic-release plugins, including `@semantic-release/exec`, `@semantic-release/changelog`, `@semantic-release/git`, and `conventional-changelog-conventionalcommits`, improving control over the release process.